### PR TITLE
Historial de partidas y estadisticas personales

### DIFF
--- a/gamey/src/bot_server/game_move.rs
+++ b/gamey/src/bot_server/game_move.rs
@@ -105,6 +105,7 @@ pub async fn make_move(
                 };
 
                 let record = db::GameRecord {
+                    username: req.username.clone(),
                     winner: Some(winner_name),
                     board_size: game.board_size(),
                     moves_count,

--- a/gamey/src/bot_server/history.rs
+++ b/gamey/src/bot_server/history.rs
@@ -1,10 +1,11 @@
-use axum::{extract::Path, Json};
-use serde::Serialize;
+use axum::{extract::{Path, Query}, Json};
+use serde::{Deserialize, Serialize};
 
 use crate::{db, error::ErrorResponse, version::check_api_version};
 
 #[derive(Serialize)]
 pub struct HistoryGame {
+    pub username: Option<String>,
     pub winner: Option<String>,
     pub board_size: u32,
     pub moves_count: usize,
@@ -18,9 +19,15 @@ pub struct HistoryResponse {
     pub games: Vec<HistoryGame>,
 }
 
+#[derive(Deserialize)]
+pub struct HistoryQuery {
+    pub username: Option<String>,
+}
+
 #[axum::debug_handler]
 pub async fn history(
     Path(api_version): Path<String>,
+    Query(query): Query<HistoryQuery>,
 ) -> Result<Json<HistoryResponse>, Json<ErrorResponse>> {
     check_api_version(&api_version)?;
 
@@ -28,13 +35,20 @@ pub async fn history(
         .await
         .map_err(|e| Json(ErrorResponse::error(&e.to_string(), Some(api_version.clone()), None)))?;
 
-    let records = db::list_recent_games(&db, 50)
-        .await
-        .map_err(|e| Json(ErrorResponse::error(&e.to_string(), Some(api_version.clone()), None)))?;
+    let records = if let Some(username) = query.username.as_deref() {
+        db::list_recent_games_by_username(&db, username, 50)
+            .await
+            .map_err(|e| Json(ErrorResponse::error(&e.to_string(), Some(api_version.clone()), None)))?
+    } else {
+        db::list_recent_games(&db, 50)
+            .await
+            .map_err(|e| Json(ErrorResponse::error(&e.to_string(), Some(api_version.clone()), None)))?
+    };
 
     let games = records
         .into_iter()
         .map(|r| HistoryGame {
+            username: r.username,
             winner: r.winner,
             board_size: r.board_size,
             moves_count: r.moves_count,
@@ -57,6 +71,7 @@ mod tests {
     #[test]
     fn history_response_serialization() {
         let game = HistoryGame {
+            username: Some("Alice".to_string()),
             winner: Some("Alice".to_string()),
             board_size: 7,
             moves_count: 42,
@@ -71,6 +86,7 @@ mod tests {
 
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("\"api_version\":\"v1\""));
+        assert!(json.contains("\"username\":\"Alice\""));
         assert!(json.contains("\"winner\":\"Alice\""));
         assert!(json.contains("\"board_size\":7"));
         assert!(json.contains("\"moves_count\":42"));
@@ -79,8 +95,10 @@ mod tests {
 
     #[tokio::test]
     async fn history_rejects_invalid_version() {
-        let result = history(Path("v0".to_string())).await;
+        let result = history(
+            Path("v0".to_string()),
+            Query(HistoryQuery { username: None }),
+        ).await;
         assert!(result.is_err());
     }
 }
-

--- a/gamey/src/cli.rs
+++ b/gamey/src/cli.rs
@@ -109,6 +109,7 @@ pub async fn run_cli_game() -> Result<()> {
                 match db::connect().await {
                     Ok(database) => {
                         let record = db::GameRecord {
+                            username: None,
                             winner: Some(winner.to_string()),
                             board_size: args.size,
                             moves_count,

--- a/gamey/src/db/mod.rs
+++ b/gamey/src/db/mod.rs
@@ -42,6 +42,7 @@ pub async fn connect() -> mongodb::error::Result<Database> {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GameRecord {
+    pub username: Option<String>,
     pub winner: Option<String>, // "Player 1", "Player 2", or None (Draw)
     pub board_size: u32,
     pub moves_count: usize,
@@ -63,6 +64,20 @@ pub async fn list_recent_games(
 ) -> mongodb::error::Result<Vec<GameRecord>> {
     let collection = db.collection::<GameRecord>("games");
     let mut cursor = collection.find(doc! {}).await?;
+    let mut games = Vec::new();
+    while let Some(doc) = cursor.try_next().await? {
+        games.push(doc);
+    }
+    Ok(sort_and_truncate(games, limit))
+}
+
+pub async fn list_recent_games_by_username(
+    db: &Database,
+    username: &str,
+    limit: i64,
+) -> mongodb::error::Result<Vec<GameRecord>> {
+    let collection = db.collection::<GameRecord>("games");
+    let mut cursor = collection.find(doc! { "username": username }).await?;
     let mut games = Vec::new();
     while let Some(doc) = cursor.try_next().await? {
         games.push(doc);
@@ -150,6 +165,7 @@ mod tests {
 
     fn make_record(ts: i64, winner: Option<&str>) -> GameRecord {
         GameRecord {
+            username: Some("alice".to_string()),
             winner: winner.map(|w| w.to_string()),
             board_size: 7,
             moves_count: 10,
@@ -196,6 +212,7 @@ mod tests {
     #[test]
     fn game_record_serde_roundtrip() {
         let original = GameRecord {
+            username: Some("alice".to_string()),
             winner: Some("Player 1".to_string()),
             board_size: 9,
             moves_count: 42,
@@ -206,6 +223,7 @@ mod tests {
         let json = serde_json::to_string(&original).unwrap();
         let restored: GameRecord = serde_json::from_str(&json).unwrap();
 
+        assert_eq!(restored.username, original.username);
         assert_eq!(restored.winner, original.winner);
         assert_eq!(restored.board_size, original.board_size);
         assert_eq!(restored.moves_count, original.moves_count);
@@ -255,6 +273,7 @@ mod tests {
     #[test]
     fn game_record_serde_roundtrip_with_none_winner() {
         let original = GameRecord {
+            username: Some("alice".to_string()),
             winner: None,
             board_size: 5,
             moves_count: 12,
@@ -265,6 +284,7 @@ mod tests {
         let json = serde_json::to_string(&original).unwrap();
         let restored: GameRecord = serde_json::from_str(&json).unwrap();
 
+        assert_eq!(restored.username, original.username);
         assert_eq!(restored.winner, None);
         assert_eq!(restored.board_size, 5);
         assert_eq!(restored.moves_count, 12);

--- a/webapp/src/GameyApi.ts
+++ b/webapp/src/GameyApi.ts
@@ -31,6 +31,7 @@ export interface Coords {
 export type GameVariant = "standard" | "why_not";
 
 export interface HistoryGame {
+    username?: string | null;
     winner: string | null;
     board_size: number;
     moves_count: number;
@@ -116,8 +117,13 @@ export async function chooseBotMove(
     return (data as BotChooseResponse).coords;
 }
 
-export async function fetchGameHistory(): Promise<HistoryGame[]> {
-    const res = await fetch(`${GAMEY_URL}/${API_VERSION}/game/history`, {
+export async function fetchGameHistory(username?: string): Promise<HistoryGame[]> {
+    const url = new URL(`${GAMEY_URL}/${API_VERSION}/game/history`);
+    if (username && username.trim()) {
+        url.searchParams.set('username', username.trim());
+    }
+
+    const res = await fetch(url.toString(), {
         method: "GET",
         headers: { "Content-Type": "application/json" },
     });

--- a/webapp/src/UsersApi.ts
+++ b/webapp/src/UsersApi.ts
@@ -31,6 +31,15 @@ export interface RankingEntry {
     winRate: number;
 }
 
+export interface PersonalStats {
+    username: string;
+    wins: number;
+    losses: number;
+    totalGames: number;
+    winRate: number;
+    rankingPosition: number | null;
+}
+
 /**
  * Obtiene el ranking global de jugadores ordenado por victorias.
  */
@@ -39,4 +48,29 @@ export async function fetchRanking(): Promise<RankingEntry[]> {
     if (!res.ok) throw new Error('Could not fetch ranking');
     const data = await res.json();
     return data.ranking as RankingEntry[];
+}
+
+export async function fetchPersonalStats(username: string): Promise<PersonalStats> {
+    const ranking = await fetchRanking();
+    const entry = ranking.find((player) => player.username === username);
+
+    if (!entry) {
+        return {
+            username,
+            wins: 0,
+            losses: 0,
+            totalGames: 0,
+            winRate: 0,
+            rankingPosition: null,
+        };
+    }
+
+    return {
+        username: entry.username,
+        wins: entry.wins,
+        losses: entry.losses,
+        totalGames: entry.wins + entry.losses,
+        winRate: entry.winRate,
+        rankingPosition: entry.position,
+    };
 }

--- a/webapp/src/__tests__/GameyApi.test.tsx
+++ b/webapp/src/__tests__/GameyApi.test.tsx
@@ -152,6 +152,7 @@ describe('GameApi', () => {
         it('obtiene el historial y devuelve games', async () => {
             const games = [
                 {
+                    username: 'alice',
                     winner: 'B',
                     board_size: 5,
                     moves_count: 12,
@@ -168,10 +169,10 @@ describe('GameApi', () => {
                 }),
             } as Response);
 
-            const result = await fetchGameHistory();
+            const result = await fetchGameHistory('alice');
 
             expect(fetch).toHaveBeenCalledWith(
-                expect.stringContaining('/v1/game/history'),
+                expect.stringContaining('/v1/game/history?username=alice'),
                 {
                     method: 'GET',
                     headers: { 'Content-Type': 'application/json' },

--- a/webapp/src/__tests__/Pages_historial.test.tsx
+++ b/webapp/src/__tests__/Pages_historial.test.tsx
@@ -25,6 +25,7 @@ describe('Historial', () => {
 
         await waitFor(() => {
             expect(fetchGameHistory).toHaveBeenCalledTimes(1);
+            expect(fetchGameHistory).toHaveBeenCalledWith('Manuel');
         });
     });
 

--- a/webapp/src/__tests__/Ranking.test.tsx
+++ b/webapp/src/__tests__/Ranking.test.tsx
@@ -9,11 +9,11 @@ vi.mock('../UsersApi', async () => {
     const actual = await vi.importActual<typeof import('../UsersApi')>('../UsersApi');
     return {
         ...actual,
-        fetchRanking: vi.fn(),
+        fetchPersonalStats: vi.fn(),
     };
 });
 
-const mockedFetchRanking = vi.mocked(UsersApi.fetchRanking);
+const mockedFetchPersonalStats = vi.mocked(UsersApi.fetchPersonalStats);
 
 describe('Ranking', () => {
     const onBack = vi.fn();
@@ -23,17 +23,31 @@ describe('Ranking', () => {
     });
 
     it('renderiza el header correctamente', async () => {
-        mockedFetchRanking.mockResolvedValue([]);
+        mockedFetchPersonalStats.mockResolvedValue({
+            username: 'Ana',
+            wins: 0,
+            losses: 0,
+            totalGames: 0,
+            winRate: 0,
+            rankingPosition: null,
+        });
 
         render(<Ranking username="Ana" onBack={onBack} />);
 
-        expect(screen.getByText(/Ranking/i)).toBeInTheDocument();
+        expect(screen.getByText(/Estadísticas personales/i)).toBeInTheDocument();
         expect(screen.getByRole('button', { name: /Volver/i })).toBeInTheDocument();
     });
 
     it('llama a onBack al pulsar Volver', async () => {
         const user = userEvent.setup();
-        mockedFetchRanking.mockResolvedValue([]);
+        mockedFetchPersonalStats.mockResolvedValue({
+            username: 'Ana',
+            wins: 0,
+            losses: 0,
+            totalGames: 0,
+            winRate: 0,
+            rankingPosition: null,
+        });
 
         render(<Ranking username="Ana" onBack={onBack} />);
 
@@ -41,33 +55,47 @@ describe('Ranking', () => {
         expect(onBack).toHaveBeenCalledTimes(1);
     });
 
-    it('muestra mensaje de vacío cuando no hay jugadores', async () => {
-        mockedFetchRanking.mockResolvedValue([]);
+    it('muestra las estadísticas del usuario autenticado', async () => {
+        mockedFetchPersonalStats.mockResolvedValue({
+            username: 'Ana',
+            wins: 7,
+            losses: 3,
+            totalGames: 10,
+            winRate: 70,
+            rankingPosition: 2,
+        });
 
         render(<Ranking username="Ana" onBack={onBack} />);
 
         await waitFor(() => {
-            expect(screen.getByText(/Todavía no hay jugadores en el ranking/i)).toBeInTheDocument();
+            expect(screen.getByText('Ana')).toBeInTheDocument();
+            expect(screen.getByText('10')).toBeInTheDocument();
+            expect(screen.getByText('7')).toBeInTheDocument();
+            expect(screen.getByText('3')).toBeInTheDocument();
+            expect(screen.getByText('70%')).toBeInTheDocument();
+            expect(screen.getByText(/Puesto actual en el ranking global: #2/i)).toBeInTheDocument();
         });
     });
 
-    it('marca al usuario actual con el chip "Tú"', async () => {
-        mockedFetchRanking.mockResolvedValue([
-            { position: 1, username: 'Ana', wins: 0, losses: 0, winRate: 0 },
-        ]);
+    it('muestra mensaje cuando el usuario aún no aparece en ranking', async () => {
+        mockedFetchPersonalStats.mockResolvedValue({
+            username: 'Ana',
+            wins: 0,
+            losses: 0,
+            totalGames: 0,
+            winRate: 0,
+            rankingPosition: null,
+        });
 
         render(<Ranking username="Ana" onBack={onBack} />);
 
         await waitFor(() => {
-            // Ana aparece tanto en el header como en la lista
-            const anas = screen.getAllByText('Ana');
-            expect(anas.length).toBeGreaterThanOrEqual(1);
-            expect(screen.getByText('Tú')).toBeInTheDocument();
+            expect(screen.getByText(/Todavía no apareces en el ranking global/i)).toBeInTheDocument();
         });
     });
 
-    it('muestra error si fetchRanking falla', async () => {
-        mockedFetchRanking.mockRejectedValue(new Error('Could not fetch ranking'));
+    it('muestra error si fetchPersonalStats falla', async () => {
+        mockedFetchPersonalStats.mockRejectedValue(new Error('Could not fetch ranking'));
 
         render(<Ranking username="Ana" onBack={onBack} />);
 
@@ -77,7 +105,7 @@ describe('Ranking', () => {
     });
 
     it('muestra el spinner mientras carga', () => {
-        mockedFetchRanking.mockReturnValue(new Promise(() => {}));
+        mockedFetchPersonalStats.mockReturnValue(new Promise(() => {}));
 
         render(<Ranking username="Ana" onBack={onBack} />);
 

--- a/webapp/src/__tests__/Ranking.test.tsx
+++ b/webapp/src/__tests__/Ranking.test.tsx
@@ -68,7 +68,7 @@ describe('Ranking', () => {
         render(<Ranking username="Ana" onBack={onBack} />);
 
         await waitFor(() => {
-            expect(screen.getByText('Ana')).toBeInTheDocument();
+            expect(screen.getAllByText('Ana').length).toBeGreaterThan(0);
             expect(screen.getByText('10')).toBeInTheDocument();
             expect(screen.getByText('7')).toBeInTheDocument();
             expect(screen.getByText('3')).toBeInTheDocument();

--- a/webapp/src/__tests__/UsersApi.test.tsx
+++ b/webapp/src/__tests__/UsersApi.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { fetchRanking, recordGameResult } from '../UsersApi';
+import { fetchRanking, fetchPersonalStats, recordGameResult } from '../UsersApi';
 
 describe('UsersApi', () => {
     beforeEach(() => {
@@ -56,6 +56,50 @@ describe('UsersApi', () => {
 
             const result = await fetchRanking();
             expect(result).toEqual([]);
+        });
+    });
+
+    describe('fetchPersonalStats', () => {
+        it('devuelve las estadísticas del usuario cuando existe en el ranking', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    ranking: [
+                        { position: 2, username: 'alice', wins: 4, losses: 1, winRate: 80 },
+                    ],
+                }),
+            } as Response);
+
+            const result = await fetchPersonalStats('alice');
+
+            expect(result).toEqual({
+                username: 'alice',
+                wins: 4,
+                losses: 1,
+                totalGames: 5,
+                winRate: 80,
+                rankingPosition: 2,
+            });
+        });
+
+        it('devuelve estadísticas vacías si el usuario no está en el ranking', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    ranking: [],
+                }),
+            } as Response);
+
+            const result = await fetchPersonalStats('alice');
+
+            expect(result).toEqual({
+                username: 'alice',
+                wins: 0,
+                losses: 0,
+                totalGames: 0,
+                winRate: 0,
+                rankingPosition: null,
+            });
         });
     });
 

--- a/webapp/src/pages/Historial.tsx
+++ b/webapp/src/pages/Historial.tsx
@@ -38,7 +38,7 @@ export default function Historial({ username, onBack }: HistorialProps) {
             setLoading(true);
             setError(null);
             try {
-                const data = await fetchGameHistory();
+                const data = await fetchGameHistory(username);
                 if (!cancelled) setGames(data);
             } catch (e) {
                 if (!cancelled)
@@ -49,7 +49,7 @@ export default function Historial({ username, onBack }: HistorialProps) {
         };
         load();
         return () => { cancelled = true; };
-    }, []);
+    }, [username]);
 
     return (
         <Box sx={{

--- a/webapp/src/pages/Menu.tsx
+++ b/webapp/src/pages/Menu.tsx
@@ -215,7 +215,7 @@ export default function Menu({ onLogout, onJugar, initialUsername, onVerHistoria
                         '&:hover': { borderColor: '#ffd54f', color: '#ffd54f' },
                     }}
                 >
-                    Ranking
+                    Estadísticas personales
                 </Button>
             </Stack>
         </Box>

--- a/webapp/src/pages/Ranking.tsx
+++ b/webapp/src/pages/Ranking.tsx
@@ -7,25 +7,46 @@ import {
     Stack,
     CircularProgress,
     Alert,
-    Chip,
 } from '@mui/material';
-import { ArrowBack, EmojiEvents } from '@mui/icons-material';
-import { fetchRanking, type RankingEntry } from '../UsersApi';
+import { ArrowBack, BarChart } from '@mui/icons-material';
+import { fetchPersonalStats, type PersonalStats } from '../UsersApi';
 
 type RankingProps = {
     username: string;
     onBack: () => void;
 };
 
-// Colores y medallas para las 3 primeras posiciones
-const POSITION_STYLE: Record<number, { color: string; medal: string }> = {
-    1: { color: '#ffd54f', medal: '🥇' },
-    2: { color: '#b0bec5', medal: '🥈' },
-    3: { color: '#ff8a65', medal: '🥉' },
+type StatCardProps = {
+    label: string;
+    value: string | number;
+    color: string;
 };
 
+function StatCard({ label, value, color }: StatCardProps) {
+    return (
+        <Paper
+            elevation={2}
+            sx={{
+                p: 2,
+                flex: 1,
+                backgroundColor: 'rgba(255,255,255,0.03)',
+                border: `1px solid ${color}55`,
+                borderRadius: 2,
+                minWidth: 140,
+            }}
+        >
+            <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.45)', letterSpacing: 1.5 }}>
+                {label}
+            </Typography>
+            <Typography variant="h4" fontWeight={800} sx={{ color, lineHeight: 1.1, mt: 1 }}>
+                {value}
+            </Typography>
+        </Paper>
+    );
+}
+
 export default function Ranking({ username, onBack }: RankingProps) {
-    const [ranking, setRanking] = useState<RankingEntry[]>([]);
+    const [stats, setStats] = useState<PersonalStats | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
@@ -35,18 +56,19 @@ export default function Ranking({ username, onBack }: RankingProps) {
             setLoading(true);
             setError(null);
             try {
-                const data = await fetchRanking();
-                if (!cancelled) setRanking(data);
+                const data = await fetchPersonalStats(username);
+                if (!cancelled) setStats(data);
             } catch (e) {
-                if (!cancelled)
+                if (!cancelled) {
                     setError(e instanceof Error ? e.message : 'Error de red');
+                }
             } finally {
                 if (!cancelled) setLoading(false);
             }
         };
         load();
         return () => { cancelled = true; };
-    }, []);
+    }, [username]);
 
     return (
         <Box sx={{
@@ -60,21 +82,19 @@ export default function Ranking({ username, onBack }: RankingProps) {
             gap: 2,
         }}>
             <Box sx={{ width: '100%', maxWidth: 700 }}>
-
-                {/* Header */}
                 <Stack direction="row" justifyContent="space-between" alignItems="center" mb={3}>
                     <Box>
                         <Typography variant="overline"
                                     sx={{ color: 'rgba(255,255,255,0.4)', letterSpacing: 3 }}>
-                            GLOBAL
+                            PERSONAL
                         </Typography>
                         <Typography variant="h6" fontWeight={800}>
-                            <EmojiEvents sx={{ mr: 1, color: '#ffd54f', verticalAlign: 'middle' }} />
-                            Ranking
-                            <Typography component="span" variant="caption"
-                                        sx={{ ml: 1, color: 'rgba(255,255,255,0.4)', letterSpacing: 2 }}>
-                                {username}
-                            </Typography>
+                            <BarChart sx={{ mr: 1, color: '#4fc3f7', verticalAlign: 'middle' }} />
+                            Estadísticas personales
+                        </Typography>
+                        <Typography variant="caption"
+                                    sx={{ color: 'rgba(255,255,255,0.45)', letterSpacing: 2 }}>
+                            {username}
                         </Typography>
                     </Box>
                     <Button
@@ -88,131 +108,51 @@ export default function Ranking({ username, onBack }: RankingProps) {
                     </Button>
                 </Stack>
 
-                {/* Loading */}
                 {loading && (
                     <Box sx={{ display: 'flex', justifyContent: 'center', my: 4 }}>
                         <CircularProgress sx={{ color: '#4fc3f7' }} />
                     </Box>
                 )}
 
-                {/* Error */}
-                {error && (
+                {!loading && error && (
                     <Alert severity="error"
                            sx={{ bgcolor: 'rgba(211,47,47,0.15)', color: '#ff6b6b', mb: 2 }}>
                         {error}
                     </Alert>
                 )}
 
-                {/* Empty */}
-                {!loading && !error && ranking.length === 0 && (
-                    <Typography variant="body1" sx={{ opacity: 0.5, textAlign: 'center', mt: 4 }}>
-                        Todavía no hay jugadores en el ranking.
-                    </Typography>
+                {!loading && !error && stats && (
+                    <Stack spacing={2}>
+                        <Paper
+                            elevation={2}
+                            sx={{
+                                p: 2.5,
+                                backgroundColor: 'rgba(79,195,247,0.08)',
+                                border: '1px solid rgba(79,195,247,0.25)',
+                                borderRadius: 2,
+                            }}
+                        >
+                            <Typography variant="subtitle2" sx={{ color: 'rgba(255,255,255,0.5)' }}>
+                                Resumen de cuenta
+                            </Typography>
+                            <Typography variant="h5" fontWeight={800} sx={{ mt: 0.5 }}>
+                                {stats.username}
+                            </Typography>
+                            <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.55)', mt: 1 }}>
+                                {stats.rankingPosition === null
+                                    ? 'Todavía no apareces en el ranking global.'
+                                    : `Puesto actual en el ranking global: #${stats.rankingPosition}`}
+                            </Typography>
+                        </Paper>
+
+                        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+                            <StatCard label="PARTIDAS" value={stats.totalGames} color="#ffffff" />
+                            <StatCard label="VICTORIAS" value={stats.wins} color="#4fc3f7" />
+                            <StatCard label="DERROTAS" value={stats.losses} color="#ef5350" />
+                            <StatCard label="RATIO" value={`${stats.winRate}%`} color="#ffd54f" />
+                        </Stack>
+                    </Stack>
                 )}
-
-                {/* Ranking list */}
-                <Stack spacing={1.5}>
-                    {ranking.map((entry) => {
-                        const posStyle = POSITION_STYLE[entry.position];
-                        const isCurrentUser = entry.username === username;
-
-                        return (
-                            <Paper
-                                key={entry.username}
-                                elevation={2}
-                                sx={{
-                                    p: 2,
-                                    backgroundColor: isCurrentUser
-                                        ? 'rgba(79,195,247,0.08)'
-                                        : 'rgba(255,255,255,0.03)',
-                                    border: `1px solid ${isCurrentUser
-                                        ? 'rgba(79,195,247,0.3)'
-                                        : posStyle
-                                            ? `${posStyle.color}40`
-                                            : 'rgba(255,255,255,0.06)'}`,
-                                    borderRadius: 2,
-                                    transition: 'all 0.2s',
-                                    '&:hover': {
-                                        bgcolor: isCurrentUser
-                                            ? 'rgba(79,195,247,0.12)'
-                                            : 'rgba(255,255,255,0.06)',
-                                    },
-                                }}
-                            >
-                                <Stack direction="row" alignItems="center" spacing={2}>
-
-                                    {/* Posición */}
-                                    <Box sx={{
-                                        minWidth: 40,
-                                        textAlign: 'center',
-                                        fontSize: posStyle ? '1.5rem' : '1rem',
-                                        color: posStyle ? posStyle.color : 'rgba(255,255,255,0.3)',
-                                        fontWeight: 800,
-                                    }}>
-                                        {posStyle ? posStyle.medal : `#${entry.position}`}
-                                    </Box>
-
-                                    {/* Nombre */}
-                                    <Box sx={{ flex: 1 }}>
-                                        <Stack direction="row" alignItems="center" spacing={1}>
-                                            <Typography variant="subtitle1" fontWeight={700}
-                                                        sx={{ color: isCurrentUser ? '#4fc3f7' : 'white' }}>
-                                                {entry.username}
-                                            </Typography>
-                                            {isCurrentUser && (
-                                                <Chip label="Tú" size="small" sx={{
-                                                    bgcolor: 'rgba(79,195,247,0.15)',
-                                                    color: '#4fc3f7',
-                                                    border: '1px solid #4fc3f7',
-                                                    height: 20,
-                                                    fontSize: '0.65rem',
-                                                }} />
-                                            )}
-                                        </Stack>
-                                        <Typography variant="caption"
-                                                    sx={{ color: 'rgba(255,255,255,0.3)' }}>
-                                            {entry.wins + entry.losses} partidas jugadas
-                                        </Typography>
-                                    </Box>
-
-                                    {/* Stats */}
-                                    <Stack direction="row" spacing={2} alignItems="center">
-                                        <Box textAlign="center">
-                                            <Typography variant="h6" fontWeight={800}
-                                                        sx={{ color: '#4fc3f7', lineHeight: 1 }}>
-                                                {entry.wins}
-                                            </Typography>
-                                            <Typography variant="caption"
-                                                        sx={{ color: 'rgba(255,255,255,0.3)' }}>
-                                                victorias
-                                            </Typography>
-                                        </Box>
-                                        <Box textAlign="center">
-                                            <Typography variant="h6" fontWeight={800}
-                                                        sx={{ color: '#ef5350', lineHeight: 1 }}>
-                                                {entry.losses}
-                                            </Typography>
-                                            <Typography variant="caption"
-                                                        sx={{ color: 'rgba(255,255,255,0.3)' }}>
-                                                derrotas
-                                            </Typography>
-                                        </Box>
-                                        <Box textAlign="center">
-                                            <Typography variant="h6" fontWeight={800}
-                                                        sx={{ color: '#ffd54f', lineHeight: 1 }}>
-                                                {entry.winRate}%
-                                            </Typography>
-                                            <Typography variant="caption"
-                                                        sx={{ color: 'rgba(255,255,255,0.3)' }}>
-                                                ratio
-                                            </Typography>
-                                        </Box>
-                                    </Stack>
-                                </Stack>
-                            </Paper>
-                        );
-                    })}
-                </Stack>
             </Box>
         </Box>
     );


### PR DESCRIPTION
## Resumen
- filtra el historial de partidas por el usuario autenticado
- guarda el username en los registros de partida para poder recuperar el historial personal
- sustituye la vista de ranking global por una vista de estadisticas personales
