### PR TITLE
Pantalla informativa al rendirse o salir de una partida

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Alert, Snackbar } from '@mui/material';
 import './App.css';
 import './styles/Additions.css';
 import Inicio from './pages/Inicio';
@@ -39,6 +40,7 @@ export default function App() {
   const [gameVariant, setGameVariant] = useState<GameVariant>('standard');
   const [botId, setBotId] = useState<BotId>('side_bot');
   const [inicioAuthMode, setInicioAuthMode] = useState<'login' | 'register'>('login');
+  const [gameExitNotice, setGameExitNotice] = useState<string | null>(null);
 
   // ── Handlers de navegación ────────────────────────────────────────────────
 
@@ -71,6 +73,11 @@ export default function App() {
     setGameMode(mode);
     setBoardSize(size);
     setView('pregame');
+  };
+
+  const exitGame = () => {
+    setGameExitNotice('Has abandonado la partida. Se ha registrado como rendición.');
+    setView('menu');
   };
 
   // ── Render ────────────────────────────────────────────────────────────────
@@ -125,7 +132,7 @@ export default function App() {
                   boardSize={boardSize}
                   variant={gameVariant}
                   botId={botId}
-                  onExit={() => setView('menu')}
+                  onExit={exitGame}
               />
           )}
 
@@ -144,6 +151,21 @@ export default function App() {
           )}
 
         </FadeView>
+        <Snackbar
+            open={Boolean(gameExitNotice)}
+            autoHideDuration={3500}
+            onClose={() => setGameExitNotice(null)}
+            anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        >
+          <Alert
+              onClose={() => setGameExitNotice(null)}
+              severity="info"
+              variant="filled"
+              sx={{ width: '100%' }}
+          >
+            {gameExitNotice}
+          </Alert>
+        </Snackbar>
       </main>
   );
 }

--- a/webapp/src/__tests__/App.test.tsx
+++ b/webapp/src/__tests__/App.test.tsx
@@ -237,6 +237,7 @@ describe('App', () => {
 
     expect(screen.getByText('Menu mock')).toBeInTheDocument();
     expect(screen.getByText('Usuario inicial: Lucia')).toBeInTheDocument();
+    expect(screen.getByText('Has abandonado la partida. Se ha registrado como rendición.')).toBeInTheDocument();
     expect(screen.getByTestId('fade-view')).toHaveAttribute('data-viewkey', 'menu');
   });
 });


### PR DESCRIPTION
## Resumen
Se añade una notificación visual al abandonar una partida para informar al usuario de que la salida se registra como rendición.
